### PR TITLE
Allow different token separators for each hyphenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Library is published to maven central and can be added to your project in the st
   <dependency>
     <groupId>io.github.nianna</groupId>
     <artifactId>hyphenator</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
   </dependency>
 
 </dependencies>
@@ -79,12 +79,12 @@ System.out.println(result.read()); // prints "Testing (auto-matic) HyPHeN-AtioN 
 ```
 
 ### Customizing input word separator
-To customize the separator on which text is supposed to be split into tokens pass the _tokenSeparator_ argument to the _Hyphenator_.
+To customize the separator on which text is supposed to be split into tokens pass the _tokenSeparator_ argument to the _Hyphenator::hyphenateText_ method.
 ```java
 List<String> patterns = ... // load the patterns from the patterns file
-Hyphenator hyphenator = new Hyphenator(patterns, new HyphenatorProperties(), "|");
+Hyphenator hyphenator = new Hyphenator(patterns);
 
-HyphenatedText result = hyphenator.hyphenateText("Testing|(automatic)|HyPHeNAtioN|by|computer!");
+HyphenatedText result = hyphenator.hyphenateText("Testing|(automatic)|HyPHeNAtioN|by|computer!", "|");
 
 System.out.println(result.read()); // prints "Test-ing (au-to-mat-ic) Hy-PHeN-AtioN by com-put-er!"
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.nianna</groupId>
     <artifactId>hyphenator</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/io/github/nianna/api/Hyphenator.java
+++ b/src/main/java/io/github/nianna/api/Hyphenator.java
@@ -41,8 +41,6 @@ public class Hyphenator {
 
     private final HyphenIndexFinder hyphenIndexFinder;
 
-    private final String tokenSeparatorPattern;
-
     /**
      * @param patterns list of TeX patterns to be used for hyphenation
      */
@@ -67,17 +65,28 @@ public class Hyphenator {
         Utils.checkArgument(nonNull(hyphenatorProperties), "Properties can not be null");
         hyphenIndexFinder = new HyphenIndexFinder(patterns, hyphenatorProperties);
         Utils.checkArgument(Utils.isNotEmpty(tokenSeparator), "Token separator can not be empty");
-        this.tokenSeparatorPattern = Pattern.quote(tokenSeparator);
     }
 
     /**
-     * Splits the given text into tokens and hyphenates it.
+     * Splits the given text into tokens on spaces and hyphenates it.
      *
      * @param text text to be hyphenated
      * @return representation of hyphenated text
      */
     public HyphenatedText hyphenateText(String text) {
-        List<HyphenatedToken> hyphenatedTokens = tokenize(text)
+        return hyphenateText(text, DEFAULT_TOKEN_SEPARATOR);
+    }
+
+
+    /**
+     * Splits the given text into tokens on specified separator and hyphenates it.
+     *
+     * @param text text to be hyphenated
+     * @param tokenSeparator separator used to split text into tokens
+     * @return representation of hyphenated text
+     */
+    public HyphenatedText hyphenateText(String text, String tokenSeparator) {
+        List<HyphenatedToken> hyphenatedTokens = tokenize(text, tokenSeparator)
                 .map(this::hyphenateToken)
                 .toList();
         return new HyphenatedText(hyphenatedTokens);
@@ -93,7 +102,8 @@ public class Hyphenator {
         return new HyphenatedToken(token, hyphenationIndexes);
     }
 
-    private Stream<String> tokenize(String text) {
+    private Stream<String> tokenize(String text, String tokenSeparator) {
+        String tokenSeparatorPattern = Pattern.quote(tokenSeparator);
         return Stream.of(text.split(tokenSeparatorPattern));
     }
 

--- a/src/test/java/io/github/nianna/api/HyphenatorTest.java
+++ b/src/test/java/io/github/nianna/api/HyphenatorTest.java
@@ -88,8 +88,7 @@ class HyphenatorTest {
 
     @Test
     void shouldHyphenateMultiTokenTextWithCustomTokenSeparator() {
-        Hyphenator hyphenator = new Hyphenator(TestUtil.loadPlPatterns(), hyphenatorProperties, "|");
-        HyphenatedText result = hyphenator.hyphenateText("Aligator|był|bardzo|głodny");
+        HyphenatedText result = hyphenator.hyphenateText("Aligator|był|bardzo|głodny", "|");
         assertEquals("A-li-ga-tor był bar-dzo głod-ny", result.read());
         List<HyphenatedToken> tokens = result.hyphenatedTokens();
         assertEquals(4, tokens.size());


### PR DESCRIPTION
Same hyphenator can now be reused to hyphenate text using different token separators.